### PR TITLE
Get All Financial Types to choose under WooCommerce CiviCRM Settings 

### DIFF
--- a/includes/class-woocommerce-civicrm-helper.php
+++ b/includes/class-woocommerce-civicrm-helper.php
@@ -580,10 +580,11 @@ class Woocommerce_CiviCRM_Helper {
 			return $this->financial_types;
 		}
 
-		$params = [
-			'sequential' => 1,
-			'is_active' => 1,
-		];
+    $params = [
+      'sequential' => 1,
+      'is_active' => 1,
+      'options' => ['limit' => 0],
+    ];
 
 		/**
 		 * Filter Financial type params before calling the Civi's API.


### PR DESCRIPTION
Steps to replicate: 
1. Go to WooCommerce CiviCRM Settings page
2. Select any Financial Type drop down

BEFORE
---------
It show first 25 active Financial Type in dropdown options 

AFTER
------- 
It show all the active Financial Type in dropdown options 

