### PR TITLE
Prevent source update for existing contact

### DIFF
--- a/includes/class-woocommerce-civicrm-manager.php
+++ b/includes/class-woocommerce-civicrm-manager.php
@@ -338,7 +338,7 @@ class Woocommerce_CiviCRM_Manager {
 		$ids = CRM_Dedupe_Finder::dupesByParams( $dedupe_params, $contact['contact_type'], 'Unsupervised' );
 
 		if ( $ids ) {
-			$cid = $ids['0'];
+			$contact['id'] = $cid = $ids['0'];
 			$action = 'update';
 		}
 
@@ -348,7 +348,8 @@ class Woocommerce_CiviCRM_Manager {
 			$contact['display_name'] = "{$fname} {$lname}";
 		}
 
-		if ( empty( $contact['contact_source'] ) ) {
+		// prevent updating source for an existing contact
+		if (empty($contact['contact_source']) && empty($contact['id'])) {
 			$contact['contact_source'] = __( 'Woocommerce purchase', 'woocommerce-civicrm' );
 		}
 


### PR DESCRIPTION
I have made the following changes:
1. Set the contact ID if dupe found on basis of unsupervised rule 
2. Prevent updating the source for existing contact 