### PR TITLE
Unable to create contribution on multisite with single civicrm instance

### DIFF
--- a/includes/class-woocommerce-civicrm-helper.php
+++ b/includes/class-woocommerce-civicrm-helper.php
@@ -160,6 +160,7 @@ class Woocommerce_CiviCRM_Helper {
 					[
 						'sequential' => 1,
 						'uf_id' => $wp_user_id,
+						'domain_id' => CRM_Core_Config::domainID(),
 					]
 				);
 				if ( 1 === $uf_match['count'] ) {


### PR DESCRIPTION
Steps to replicate: 

1. I got a multisite site (site A [domain ID - 1] and B [domain ID - 2]) setup with single CiviCRM instance.
2. There are two records with the same uf_match.uf_id (aka CMS user ID) but linked with a different domain ID in other words belong to different sites.  
3. After woocommerce purchase on-site B (domain ID - 2) theres is no linked contact and contribution in order edit page. The note says `CiviCRM Contact could not be fetched`

This patch fixes the issue. 